### PR TITLE
Travis integration with proper docker image generation and push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+
+node_js: 14
+
+services:
+  - docker
+
+script:
+  - npm test
+  - |
+    if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]
+    then  
+      docker build -t "$DOCKER_HUB_USERNAME/ui:$TRAVIS_COMMIT" .
+      docker tag "$DOCKER_HUB_USERNAME/ui:$TRAVIS_COMMIT" "$DOCKER_HUB_USERNAME/ui:latest"
+      echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
+      docker push "$DOCKER_HUB_USERNAME/ui:$TRAVIS_COMMIT"
+      docker push "$DOCKER_HUB_USERNAME/ui:latest"
+    fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM node:12-slim
+FROM node:14
 WORKDIR ui
 COPY package.json ./
 RUN npm install
 COPY . ./
 EXPOSE 8080
-ARG NODE_ENV=production
-ENV NODE_ENV=${NODE_ENV}
-RUN npm run prod:server
-CMD ["node", "client/server.js"]
+RUN npm run prod:client
+CMD ["node", "server/client.js"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Books UI
+### Master
+![Build status](https://travis-ci.org/programowanie-zespolowe-alek-shaf/UI.svg?branch=master)
 
 #### TODO LIST: App.js end
 


### PR DESCRIPTION
https://hub.docker.com/repository/docker/553377995899929464339267475442/ui/
Spreparowałem takiego usera `553377995899929464339267475442` na docker hubie, hasło jest długie i losowe. Mam je w keyvaultcie prywatnym - jak będzie potrzeba to mogę udostępnić. Dodałem go do sekretów w Travisie.
Ten pipeline puszcza wasze UT (na razie ich nie ma i nie wiem czy będziecie je wgl robić), buduje dockera i wrzuca go do docker huba.

@erykjarocki : 
1. Jeśli chcesz, to temat który można rozczaić to jak zawołać uwierzytelniony `kubectl apply -f <k8s_manifest>` do Google Kubernetes Engine z travisa. Bez tego, trzeba będzie z biurka strzelać do klastra ręcznie. Gdyby to ogarnąć, to kubernetes byłby stawiany z pipeline'u i mamy wszystko zrobione - CI i CD. Teraz mamy tylko CI.
2. Nie wiem jak oni sobie poradzą z tymi dockerfilami, to jest proste, ale po prostu nie chciałem robić za wszystkich wszystkiego. Ale jak już będzie jeden dockerfile dla Java'ovego projektu to będzie luz.
3. Z tym ingressem co Ci pisałem jest o tyle mały problem, że to co chciałem zrobić trzeba nieco na około. Więc zastanawiam się czy nie można pójść na skróty.
Jak będziesz mieć chwilę to musimy się zdzwonić jakoś i pogadać. 

A BTW - nie wiedziałem czy dogadaliście się z tym czy zmiany pchacie bezpośrednio na mastera czy przez pull requesty - dlatego wystawiłem PR. Mastera najlepiej zablokować z ustawień repozytorium. 
Konflikty to jedno, jak ktoś umie gita to to nie jest żaden problem. Większym plusem jest to, że możecie sobie robić wzajemnie review zmian.